### PR TITLE
Update voodoo_winit

### DIFF
--- a/voodoo_winit/Cargo.toml
+++ b/voodoo_winit/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["vulkan", "gpu", "gpgpu", "graphics"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-winit = "0.8"
-voodoo = { version = "~0.2.1", path = ".." }
+winit = "0.10"
+voodoo = { version = "0.3", path = ".." }


### PR DESCRIPTION
Update the voodoo_winit crate to work with the new update to Voodoo. Also updates the winit version.