### PR TITLE
Hide Loader::destroy_instance from public docs

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -204,7 +204,7 @@ impl Loader {
     //
     // *PFN_vkDestroyInstance)(VkInstance instance, const
     // VkAllocationCallbacks* pAllocator);
-    pub fn destroy_instance(&self, instance: InstanceHandle,
+    pub (crate) fn destroy_instance(&self, instance: InstanceHandle,
             allocator: Option<*const vks::VkAllocationCallbacks>) {
         let allocator = allocator.unwrap_or(ptr::null());
         unsafe { self.instance_proc_addr_loader().vk


### PR DESCRIPTION
The `destroy_instance` function is confusing: since it appears in the public API, it made me think I need to manually destroy the Vulkan `Instance`, when it is in fact automatically called by the `Drop` implementation.

This pull request makes that function `pub (crate)` so it doesn't appear in the public docs.