### PR TITLE
WIP: Use slices of proper size with PhysicalDeviceMemoryProperties

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -177,12 +177,13 @@ impl Device {
     pub fn memory_type_index(&self, type_filter: u32, properties: ::MemoryPropertyFlags)
             -> VdResult<u32> {
         let mem_props = self.physical_device().memory_properties();
+        let mem_types = mem_props.memory_types();
 
-        for i in 0..mem_props.memory_type_count() {
+        for (i, mem_type) in mem_types.iter().enumerate() {
             if (type_filter & (1 << i)) != 0 &&
-                (mem_props.memory_types()[i as usize].property_flags() & properties) == properties
+                (mem_type.property_flags() & properties) == properties
             {
-                return Ok(i);
+                return Ok(i as u32);
             }
         }
         panic!("failed to find suitable memory type index with: type_filter: '{}', properties: '{:?}'",

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -2290,12 +2290,9 @@ impl PhysicalDeviceMemoryProperties {
         PhysicalDeviceMemoryProperties { raw, }
     }
 
-    pub fn memory_type_count<'a>(&'a self) -> u32 {
-        self.raw.memoryTypeCount.into()
-    }
-
     pub fn memory_types<'a>(&'a self) -> &[MemoryType] {
-        unsafe { slice::from_raw_parts(&self.raw.memoryTypes as *const vks::VkMemoryType as *const _, vks::VK_MAX_MEMORY_TYPES as usize) }
+        let count = self.raw.memoryTypeCount as usize;
+        unsafe { std::mem::transmute(&self.raw.memoryTypes[..count]) }
     }
 
     pub fn memory_heap_count<'a>(&'a self) -> u32 {
@@ -2303,7 +2300,8 @@ impl PhysicalDeviceMemoryProperties {
     }
 
     pub fn memory_heaps<'a>(&'a self) -> &[MemoryHeap] {
-        unsafe { slice::from_raw_parts(&self.raw.memoryHeaps as *const vks::VkMemoryHeap as *const _, vks::VK_MAX_MEMORY_HEAPS as usize) }
+        let count = self.raw.memoryHeapCount as usize;
+        unsafe { std::mem::transmute(&self.raw.memoryHeaps[..count]) }
     }
 
     pub fn set_memory_type_count<'m>(&mut self, memory_type_count: u32) {


### PR DESCRIPTION
This pull request changes the MemoryProperties struct to return subslices of the right size, instead of returning a big slice with some empty structs at the end and a count of valid structures.

The issue is, I don't know how to change this in the code generator. I've only changed the generated code.

Fixes #10 