### PR TITLE
Fix corrupted Vec creation in `util::read_spir_v_file`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -149,7 +149,7 @@ pub fn read_spir_v_file<P: AsRef<Path>>(file: P) -> VdResult<Vec<u32>> {
     // TODO: Add some sort of basic verification that the file is actually
     // spir-v.
     unsafe {
-        let ptr = contents.as_mut_ptr() as *mut u32;
+        let ptr = contents.as_ptr() as *const u32;
         let new_len = contents.len() / 4;
         mem::forget(contents);
         let code = Vec::from_raw_parts(ptr, new_len, new_len);

--- a/src/util.rs
+++ b/src/util.rs
@@ -161,7 +161,7 @@ pub fn read_spir_v_file<P: AsRef<Path>>(file: P) -> VdResult<Vec<u32>> {
 /// Reads a file into a byte Vec.
 pub fn read_file<P: AsRef<Path>>(file: P) -> VdResult<Vec<u8>> {
     let file_name = file.as_ref().display().to_string();
-    let f = File::open(file).expect("shader file not found");
+    let f = File::open(file).expect(&format!("shader file '{}' not found", file_name));
     let file_bytes = f.metadata().unwrap().len() as usize;
     let mut contents = Vec::<u8>::with_capacity(file_bytes);
     let mut reader = BufReader::new(f);

--- a/src/util.rs
+++ b/src/util.rs
@@ -144,7 +144,7 @@ impl <'cs, 'p, 'q> From<&'p [&'q str]> for CharStrs<'cs> where 'q: 'p, 'p: 'cs, 
 
 /// Reads a SPIR-V file into a word Vec.
 pub fn read_spir_v_file<P: AsRef<Path>>(file: P) -> VdResult<Vec<u32>> {
-    let mut contents = read_file(file)?;
+    let contents = read_file(file)?;
     assert!(contents.len() % 4 == 0);
     assert!(mem::size_of_val(&contents[0]) == 1);
     // TODO: Add some sort of basic verification that the file is actually

--- a/src/util.rs
+++ b/src/util.rs
@@ -151,9 +151,9 @@ pub fn read_spir_v_file<P: AsRef<Path>>(file: P) -> VdResult<Vec<u32>> {
     unsafe {
         let ptr = contents.as_ptr() as *const u32;
         let new_len = contents.len() / 4;
-        mem::forget(contents);
-        let code = Vec::from_raw_parts(ptr, new_len, new_len);
-        Ok(code)
+        let slice: &[u32] = slice::from_raw_parts(ptr, new_len);
+        let vec = slice.to_vec();
+        Ok(vec)
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -142,6 +142,7 @@ impl <'cs, 'p, 'q> From<&'p [&'q str]> for CharStrs<'cs> where 'q: 'p, 'p: 'cs, 
 }
 
 
+/// Reads a SPIR-V file into a word Vec.
 pub fn read_spir_v_file<P: AsRef<Path>>(file: P) -> VdResult<Vec<u32>> {
     let mut contents = read_file(file)?;
     assert!(contents.len() % 4 == 0);


### PR DESCRIPTION
I was debugging some strange memory problems and noticed that jemalloc would regularly freak out when Rust drops the buffer containing my shader bytecode. I traced it to this method.

Using `Vec::from_raw_parts` unfortunately can corrupt the data on the heap unless the new and old types share the same size and alignment.

https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts

Instead, I used `slice::from_raw_parts` and `to_vec()` which is an in-place call (no copies) and should not incur an additional performance hit. The buffers are now dropped safely on my end.

Possibly related to #20--my issue has disappeared since this fix.